### PR TITLE
Add OpenSSL Support / Change Base58 Prefixes

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1425,6 +1425,8 @@ bool IsInitialBlockDownload()
 {
     const CChainParams& chainParams = Params();
     LOCK(cs_main);
+    if (chainActive.Height() < chainParams.GetConsensus().nChainsplitIndex + 1)
+        return false;
     if (fImporting || fReindex)
         return true;
     if (fCheckpointsEnabled && chainActive.Height() < Checkpoints::GetTotalBlocksEstimate(chainParams.Checkpoints()))
@@ -1432,15 +1434,11 @@ bool IsInitialBlockDownload()
     static bool lockIBDState = false;
     if (lockIBDState)
         return false;
-    if (chainActive.Height() >= chainParams.GetConsensus().nChainsplitIndex) {
-        bool state = (chainActive.Height() < pindexBestHeader->nHeight - 24 * 6 ||
-                pindexBestHeader->GetBlockTime() < GetTime() - chainParams.MaxTipAge());
-        if (!state)
-            lockIBDState = true;
-        return state;
-    }
-    else
-        return true;
+    bool state = (chainActive.Height() < pindexBestHeader->nHeight - 24 * 6 ||
+            pindexBestHeader->GetBlockTime() < GetTime() - chainParams.MaxTipAge());
+    if (!state)
+        lockIBDState = true;
+    return state;
 }
 
 bool fLargeWorkForkFound = false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1432,13 +1432,15 @@ bool IsInitialBlockDownload()
     static bool lockIBDState = false;
     if (lockIBDState)
         return false;
-    if (chainActive.Height() != chainParams.GetConsensus().nChainsplitIndex) {
+    if (chainActive.Height() >= chainParams.GetConsensus().nChainsplitIndex) {
         bool state = (chainActive.Height() < pindexBestHeader->nHeight - 24 * 6 ||
                 pindexBestHeader->GetBlockTime() < GetTime() - chainParams.MaxTipAge());
         if (!state)
             lockIBDState = true;
         return state;
     }
+    else
+        return true;
 }
 
 bool fLargeWorkForkFound = false;
@@ -4770,7 +4772,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
         LOCK(cs_main);
 
-        if (IsInitialBlockDownload())
+        if (IsInitialBlockDownload() && chainActive.Tip()->nHeight >= 100000)
             return true;
 
         CBlockIndex* pindex = NULL;
@@ -5495,12 +5497,25 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
         bool fFetch = state.fPreferredDownload || (nPreferredDownload == 0 && !pto->fClient && !pto->fOneShot); // Download if this is a nice peer, or we have no nice peers and this one might do.
         if (!state.fSyncStarted && !pto->fClient && !fImporting && !fReindex) {
             // Only actively request headers from a single peer, unless we're close to today.
-            if ((nSyncStarted == 0 && fFetch) || pindexBestHeader->GetBlockTime() > GetAdjustedTime() - 24 * 60 * 60) {
-                state.fSyncStarted = true;
-                nSyncStarted++;
-                CBlockIndex *pindexStart = pindexBestHeader->pprev ? pindexBestHeader->pprev : pindexBestHeader;
-                LogPrint("net", "initial getheaders (%d) to peer=%d (startheight:%d)\n", pindexStart->nHeight, pto->id, pto->nStartingHeight);
-                pto->PushMessage("getheaders", chainActive.GetLocator(pindexStart), uint256());
+            time_t t = time(0);
+            if (t < consensusParams.nChainsplitTime && chainActive.Tip()->nHeight < 110000) {
+                fFetch = true;
+                if ((nSyncStarted == 0 && fFetch) || pindexBestHeader->GetBlockTime() > GetAdjustedTime() - 14 * 24 * 60 * 60) {
+                    state.fSyncStarted = true;
+                    nSyncStarted++;
+                    CBlockIndex *pindexStart = pindexBestHeader->pprev ? pindexBestHeader->pprev : pindexBestHeader;
+                    LogPrint("net", "initial getheaders (%d) to peer=%d (startheight:%d)\n", pindexStart->nHeight, pto->id, pto->nStartingHeight);
+                    pto->PushMessage("getheaders", chainActive.GetLocator(pindexStart), uint256());
+                }
+            }
+            else {
+                if ((nSyncStarted == 0 && fFetch) || pindexBestHeader->GetBlockTime() > GetAdjustedTime() - 24 * 60 * 60) {
+                    state.fSyncStarted = true;
+                    nSyncStarted++;
+                    CBlockIndex *pindexStart = pindexBestHeader->pprev ? pindexBestHeader->pprev : pindexBestHeader;
+                    LogPrint("net", "initial getheaders (%d) to peer=%d (startheight:%d)\n", pindexStart->nHeight, pto->id, pto->nStartingHeight);
+                    pto->PushMessage("getheaders", chainActive.GetLocator(pindexStart), uint256());
+                }
             }
         }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4772,7 +4772,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
         LOCK(cs_main);
 
-        if (IsInitialBlockDownload() && chainActive.Tip()->nHeight >= 100000)
+        if (IsInitialBlockDownload() && chainActive.Tip()->nHeight >= Params().GetConsensus().nChainsplitIndex)
             return true;
 
         CBlockIndex* pindex = NULL;
@@ -5498,7 +5498,7 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
         if (!state.fSyncStarted && !pto->fClient && !fImporting && !fReindex) {
             // Only actively request headers from a single peer, unless we're close to today.
             time_t t = time(0);
-            if (t < consensusParams.nChainsplitTime && chainActive.Tip()->nHeight < 110000) {
+            if (t < consensusParams.nChainsplitTime && chainActive.Tip()->nHeight < consensusParams.nChainsplitIndex) {
                 fFetch = true;
                 if ((nSyncStarted == 0 && fFetch) || pindexBestHeader->GetBlockTime() > GetAdjustedTime() - 14 * 24 * 60 * 60) {
                     state.fSyncStarted = true;

--- a/src/metrics.cpp
+++ b/src/metrics.cpp
@@ -179,9 +179,9 @@ int printStats(bool mining)
     tlsvalidate = GetArg("-tlsvalidate","");
     std::string cipherdescription = "Not Encrypted";
     std::string securitylevel = "INACTIVE";
-    std::string routingsecrecy = "CLEARNET";
+    std::string routingsecrecy = GetArg("-onlynet", "");
     std::string validationdescription = (tlsvalidate == "1" ? "YES" : "PUBLIC");
-    if (routingsecrecy == "ipv4" || routingsecrecy == "ipv6")
+    if (routingsecrecy == "" || routingsecrecy == "ipv4" || routingsecrecy == "ipv6")
         routingsecrecy = "CLEARNET";
     else if (routingsecrecy == "onion")
         routingsecrecy = "TOR NETWORK";


### PR DESCRIPTION
This is a staging area for initial OpenSSL support to Zen and for updates to the base58 prefixes. 

- P2P socket connections are wrapped over TLS 1.2
- `PREFERRED_CIPHERS = "HIGH:!aNULL:!kRSA:!PSK:!SRP:!MD5:!RC4";`

TODO:
- ~~Check coinbase allocation functionality.~~ **completed**
- FIXME: tests/key_test.cpp is currently disabled until it can be updated with the new base58 prefixes.
- Add functionality to verify certificate chains by default (and use OCSP?)
- ~~Add functionality to generate TLS certificates and to retrieve locations from zen.conf~~ **completed**

