### PR TITLE
Move conf file

### DIFF
--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -102,23 +102,43 @@ bool AppInit(int argc, char* argv[])
         {
             ReadConfigFile(mapArgs, mapMultiArgs);
         } catch (const missing_zcash_conf& e) {
-            fprintf(stderr,
-                (_("Before starting zend, you need to create a configuration file:\n"
-                   "%s\n"
-                   "It can be completely empty! That indicates you are happy with the default\n"
-                   "configuration of zend. But requiring a configuration file to start ensures\n"
-                   "that zend won't accidentally compromise your privacy if there was a default\n"
-                   "option you needed to change.\n"
-                   "\n"
-                   "You can look at the example configuration file for suggestions of default\n"
-                   "options that you may want to change. It should be in one of these locations,\n"
-                   "depending on how you installed Zen:\n") +
-                 _("- Source code:  %s\n"
-                   "- .deb package: %s\n")).c_str(),
-                GetConfigFile().string().c_str(),
-                "contrib/DEBIAN/examples/zen.conf",
-                "/usr/share/doc/zen/examples/zen.conf");
-            return false;
+            //fprintf(stderr,
+            //    (_("Before starting zend, you need to create a configuration file:\n"
+            //       "%s\n"
+            //       "It can be completely empty! That indicates you are happy with the default\n"
+            //       "configuration of zend. But requiring a configuration file to start ensures\n"
+            //       "that zend won't accidentally compromise your privacy if there was a default\n"
+            //       "option you needed to change.\n"
+            //       "\n"
+            //       "You can look at the example configuration file for suggestions of default\n"
+            //       "options that you may want to change. It should be in one of these locations,\n"
+            //       "depending on how you installed Zen:\n") +
+            //     _("- Source code:  %s\n"
+            //       "- .deb package: %s\n")).c_str(),
+            //    GetConfigFile().string().c_str(),
+            //    "contrib/DEBIAN/examples/zen.conf",
+            //    "/usr/share/doc/zen/examples/zen.conf");
+            //return false;
+
+            // Warn user about using default config file
+            try
+            {
+                fprintf(stdout,
+                    "------------------------------------------------------------------"
+                    "WARNING: Copying the default config file to ~/.zen/zen.conf.\n"
+                    "This is a potential risk, as zend might accidentally compramize\n"
+                    "your privacy if there is a default option that you need to change!"
+                    "------------------------------------------------------------------");
+                // Copy default config file     
+                std::ifstream src("contrib/debian/examples/zen.conf", std::ios::binary);
+                std::ofstream dst("", std""ios""binary);
+                dst << src.rdbuf();
+                return true;
+            } catch (const std::exception& e) {
+                fprintf(stderr, "Error copying configuration file: %s\n", e.what());
+                return false;
+            }
+            
         } catch (const std::exception& e) {
             fprintf(stderr,"Error reading configuration file: %s\n", e.what());
             return false;

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -102,24 +102,6 @@ bool AppInit(int argc, char* argv[])
         {
             ReadConfigFile(mapArgs, mapMultiArgs);
         } catch (const missing_zcash_conf& e) {
-            //fprintf(stderr,
-            //    (_("Before starting zend, you need to create a configuration file:\n"
-            //       "%s\n"
-            //       "It can be completely empty! That indicates you are happy with the default\n"
-            //       "configuration of zend. But requiring a configuration file to start ensures\n"
-            //       "that zend won't accidentally compromise your privacy if there was a default\n"
-            //       "option you needed to change.\n"
-            //       "\n"
-            //       "You can look at the example configuration file for suggestions of default\n"
-            //       "options that you may want to change. It should be in one of these locations,\n"
-            //       "depending on how you installed Zen:\n") +
-            //     _("- Source code:  %s\n"
-            //       "- .deb package: %s\n")).c_str(),
-            //    GetConfigFile().string().c_str(),
-            //    "contrib/DEBIAN/examples/zen.conf",
-            //    "/usr/share/doc/zen/examples/zen.conf");
-            //return false;
-
             // Warn user about using default config file
             try
             {

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -127,11 +127,12 @@ bool AppInit(int argc, char* argv[])
                     "------------------------------------------------------------------\n"
                     "WARNING: Copying the default config file to ~/.zen/zen.conf.\n"
                     "This is a potential risk, as zend might accidentally compramize\n"
-                    "your privacy if there is a default option that you need to change!"
+                    "your privacy if there is a default option that you need to change!\n"
+
                     "------------------------------------------------------------------\n");
                 // Copy default config file     
                 std::ifstream src("contrib/debian/examples/zen.conf", std::ios::binary);
-                std::ofstream dst(GetConfigFile(), std::ios::binary);
+                std::ofstream dst(GetConfigFile().string().c_str(), std::ios::binary);
                 dst << src.rdbuf();
                 return true;
             } catch (const std::exception& e) {

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -131,7 +131,7 @@ bool AppInit(int argc, char* argv[])
                     "------------------------------------------------------------------\n");
                 // Copy default config file     
                 std::ifstream src("contrib/debian/examples/zen.conf", std::ios::binary);
-                std::ofstream dst("", std::ios::binary);
+                std::ofstream dst(GetConfigFile(), std::ios::binary);
                 dst << src.rdbuf();
                 return true;
             } catch (const std::exception& e) {

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -102,9 +102,9 @@ bool AppInit(int argc, char* argv[])
         {
             ReadConfigFile(mapArgs, mapMultiArgs);
         } catch (const missing_zcash_conf& e) {
-            // Warn user about using default config file
             try
             {
+                // Warn user about using default config file
                 fprintf(stdout,
                     "------------------------------------------------------------------\n"
                     "                        WARNING:\n"

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -131,7 +131,7 @@ bool AppInit(int argc, char* argv[])
                     "------------------------------------------------------------------\n");
                 // Copy default config file     
                 std::ifstream src("contrib/debian/examples/zen.conf", std::ios::binary);
-                std::ofstream dst("", std""ios""binary);
+                std::ofstream dst("", std::ios::binary);
                 dst << src.rdbuf();
                 return true;
             } catch (const std::exception& e) {

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -124,11 +124,11 @@ bool AppInit(int argc, char* argv[])
             try
             {
                 fprintf(stdout,
-                    "------------------------------------------------------------------"
+                    "------------------------------------------------------------------\n"
                     "WARNING: Copying the default config file to ~/.zen/zen.conf.\n"
                     "This is a potential risk, as zend might accidentally compramize\n"
                     "your privacy if there is a default option that you need to change!"
-                    "------------------------------------------------------------------");
+                    "------------------------------------------------------------------\n");
                 // Copy default config file     
                 std::ifstream src("contrib/debian/examples/zen.conf", std::ios::binary);
                 std::ofstream dst("", std""ios""binary);

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -125,16 +125,19 @@ bool AppInit(int argc, char* argv[])
             {
                 fprintf(stdout,
                     "------------------------------------------------------------------\n"
-                    "WARNING: Copying the default config file to ~/.zen/zen.conf.\n"
+                    "                        WARNING:\n"
+                    "Automatically copying the default config file to ~/.zen/zen.conf.\n"
                     "This is a potential risk, as zend might accidentally compramize\n"
                     "your privacy if there is a default option that you need to change!\n"
-
+                    "\n"
+                    "           Please restart zend to continue.\n"
+                    "           You will not see this warning again.\n"
                     "------------------------------------------------------------------\n");
                 // Copy default config file     
                 std::ifstream src("contrib/debian/examples/zen.conf", std::ios::binary);
                 std::ofstream dst(GetConfigFile().string().c_str(), std::ios::binary);
                 dst << src.rdbuf();
-                return true;
+                return false;
             } catch (const std::exception& e) {
                 fprintf(stderr, "Error copying configuration file: %s\n", e.what());
                 return false;


### PR DESCRIPTION
Automatically copy the default config file rather then requiring the user to do it.

This still warns the user  about the potential risks of the default config file before launching zend.